### PR TITLE
Backend: audio trimming and renaming to discrepancy measurement

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,7 +1,7 @@
 import os
 from flask import Flask, abort, request, jsonify, render_template
 from flask_cors import CORS
-from utils import text_to_speech, speech_to_text, acoustic_assess, text_to_text, store_audio, eval_revision, clip_speech_to_text
+from utils import text_to_speech, speech_to_text, evaluate_audio_discrepancy, text_to_text, store_audio, eval_revision, clip_speech_to_text
 import random
 
 from flask_limiter import Limiter
@@ -94,11 +94,11 @@ def generate_speech():
     return app.response_class(audio_data, mimetype='audio/wav')
 
 
-@app.route("/api/speeches/acoustics_scores", methods=["POST"])
+@app.route("/api/speeches/acoustic_evaluation", methods=["POST"])
 def predict_acoustics_scores():
     # audio_path = cache_audios(request.files['audio'])
     try:
-        score = acoustic_assess(request.files["query_audio"], request.files["reference_audio"])
+        score = evaluate_audio_discrepancy(request.files["query_audio"], request.files["reference_audio"])
     except Exception as e:
         abort(500, str(e))
     return jsonify({"score": score})

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -114,22 +114,6 @@ def clip_speech_to_text(audio: FileStorage) -> List[dict]:
     # finally:
     #     os.remove(audio_path)         
 
-def speech_to_text_timestamps(audio_location: str):
-    client = OpenAI(api_key=API_KEY)
-    audio_file = open(audio_location, "rb")
-    try:
-        transcription = client.audio.transcriptions.create(
-            file=audio_file,
-            model="whisper-1",
-            response_format="verbose_json",
-            timestamp_granularities=["word"],
-        )
-        return transcription.text, transcription.words
-    except Exception as e:
-        raise Exception(str(e))
-
-
-
 class TextRevision(BaseModel):
     content: str
 
@@ -190,15 +174,39 @@ def text_to_speech(input_text):
     # logging.info(f"Generated audio file saved at {audio_path}")
     return response.read()
 
+from pydub import AudioSegment
 
+def trim_audio(input_file: str, output_file: str, start_sec: float, end_sec: float = None):
+    """
+    Trim the input audio file from start_sec to end_sec and save it as output_file. \n
+    """
+    # Load the audio file
+    audio = AudioSegment.from_file(input_file)
+    # Pydub works in milliseconds
+    start_time = start_sec * 1000
 
-def acoustic_assess(query_audio: FileStorage, ref_audio: FileStorage) -> float:
+    if end_sec is None:
+
+        trimmed_audio = audio[start_time:]
+
+    else:
+
+        end_time = end_sec * 1000
+    
+        # Slice the audio
+        trimmed_audio = audio[start_time:end_time]
+    
+    # Export the result
+    trimmed_audio.export(output_file, format="wav")
+    print(f"Saved: {output_file}")
+
+def evaluate_audio_discrepancy(query_audio: FileStorage, ref_audio: FileStorage) -> float:
     """
-    Get the similarity score between two audio files. \n
+    Get the discrepancy score between two audio files. \n
     """
-    # url = "http://localhost:6000/api/similarity_scores"
-    # url = "http://speech_assessment-models-1:6000/api/similarity_scores"
-    url = f"{ACOUSTIC_URL}/api/similarity_scores"
+    # url = "http://localhost:6000/api/discrepancy_score"
+    # url = "http://speech_assessment-models-1:6000/api/discrepancy_score"
+    url = f"{ACOUSTIC_URL}/api/discrepancy_score"
     headers = {}
 
     response = requests.request(


### PR DESCRIPTION
Backend:

After https://github.com/t07902301/speech-coach/pull/17, user's audio recording can be trimmed with an offset as the start position. A simple local test shows the trimming reduces the discrepancy between a reference and the input audio. 

Is ending point needed from users' dragging actions? Will it help to reduce DTW-based discrepancy measurement furthur or DTW can handle that w/o data preprocessing? 