### PR TITLE
Feature/recording in selection player comparison

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -123,7 +123,17 @@ def predict_acoustics_scores():
     try:
         query_audio = request.files["query_audio"]
         reference_audio = request.files["reference_audio"]
-        # # load audios for local testing 
+        # 1. Get the raw strings
+        query_span_raw = request.form.get("query_span")
+        ref_span_raw = request.form.get("ref_span")
+
+        # 2. Safely parse
+        try:
+            query_span = json.loads(query_span_raw) if query_span_raw else {"start": 0, "end": 0}
+            ref_span = json.loads(ref_span_raw) if ref_span_raw else {"start": 0, "end": 0}
+        except json.JSONDecodeError:
+            return jsonify({"error": "Invalid JSON format in spans"}), 400
+        # # download audios for local testing 
         # load_fileStorage(query_audio, '../database/audios/query_audio.wav')
         # load_fileStorage(reference_audio, '../database/audios/reference_audio.wav')
         # # reset file pointer to the beginning after saving
@@ -132,7 +142,8 @@ def predict_acoustics_scores():
         score = evaluate_audio_discrepancy(
             query_audio,
             reference_audio,
-            float(request.form.get("query_start", 0)),
+            query_span=query_span,
+            ref_span=ref_span            
         )
     except Exception as e:
         abort(500, str(e))

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -233,7 +233,7 @@ def generateFileStorage(name: str) -> FileStorage:
 
 
 def evaluate_audio_discrepancy(
-    query_audio: FileStorage, ref_audio: FileStorage, query_start: float = None
+    query_audio: FileStorage, ref_audio: FileStorage, ref_span: dict, query_span: dict = None
 ) -> float:
     """
     Get the discrepancy score between a query and a reference audio.\n Trim the query audio when query_start is indicated. \n
@@ -243,16 +243,31 @@ def evaluate_audio_discrepancy(
     url = f"{ACOUSTIC_URL}/api/discrepancy_score"
     headers = {}
     temp_query_audio_path = ""
+    temp_ref_audio_path = ""
+    logger.info(f"Evaluating audio discrepancy with query_span: {query_span} and ref_span: {ref_span}")
     try:
-        if query_start is not None and query_start > 0:
-            logger.info(f"Trimming query audio from {query_start} seconds.")
-            temp_query_audio_path = tempfile.NamedTemporaryFile(
-                delete=False, suffix=os.path.splitext(query_audio.filename)[1]
-            ).name  # Create a temporary file sharing the same extension as the input audio file
+        if ref_span is not None:
+            ref_start = ref_span.get("start", 0)
+            ref_end = ref_span.get("end", None)
+            if ref_start > 0:
+                logger.info(f"Trimming reference audio from {ref_start} seconds.")
+                temp_ref_audio_path = tempfile.NamedTemporaryFile(
+                    delete=False, suffix=os.path.splitext(ref_audio.filename)[1]
+                ).name
+                trim_audio(ref_audio, temp_ref_audio_path, ref_start, ref_end)
+                ref_audio = generateFileStorage(temp_ref_audio_path)
+        if query_span is not None:
+            query_start = query_span.get("start", 0)
+            query_end = query_span.get("end", None)
+            if query_start > 0:
+                logger.info(f"Trimming query audio from {query_start} seconds.")
+                temp_query_audio_path = tempfile.NamedTemporaryFile(
+                    delete=False, suffix=os.path.splitext(query_audio.filename)[1]
+                ).name  # Create a temporary file sharing the same extension as the input audio file
 
-            trim_audio(query_audio, temp_query_audio_path, query_start)
+                trim_audio(query_audio, temp_query_audio_path, query_start, query_end)
 
-            query_audio = generateFileStorage(temp_query_audio_path)
+                query_audio = generateFileStorage(temp_query_audio_path)
 
         response = requests.request(
             "POST",
@@ -270,9 +285,12 @@ def evaluate_audio_discrepancy(
     except Exception as e:
         raise Exception(str(e))
     finally:
-        if query_start is not None and os.path.exists(temp_query_audio_path):
+        if query_span is not None and os.path.exists(temp_query_audio_path):
             os.remove(temp_query_audio_path)
             logger.info(f"Removed temporary query audio file: {temp_query_audio_path}")
+        if ref_span is not None and os.path.exists(temp_ref_audio_path):
+            os.remove(temp_ref_audio_path)
+            logger.info(f"Removed temporary reference audio file: {temp_ref_audio_path}")
 
 
 def load_fileStorage(audio: FileStorage, path: str) -> str:

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -118,13 +118,13 @@ def clip_speech_to_text(audio: FileStorage) -> List[dict]:
     finally:
         os.remove(audio_path)
 
-def fake_clip_speech_to_text(audio: FileStorage, result_file: str = 'char_ts-diarization.pkl') -> List[dict]:
+def fake_clip_speech_to_text(audio: FileStorage, result_file: str = '../tests/audios/char_ts-diarization.pkl') -> List[dict]:
     import pickle as pkl
     try:
         with open(result_file, 'rb') as file:
             # 2. Load the data from the file
             loaded_data = pkl.load(file)
-        return loaded_data['diarization_segments']
+        return loaded_data
     except Exception as e:
         raise Exception(str(e))
 

--- a/frontend/src/components/AudioSelectionPlayerRecorder.js
+++ b/frontend/src/components/AudioSelectionPlayerRecorder.js
@@ -30,10 +30,6 @@ const AudioSelectinPlayer = () => {
   const [recordingIndex, setRecordingIndex] = useState(null);
   const [userRecordings, setUserRecordings] = useState({});
   const [showRecordingTools, setShowRecordingTools] = useState(false);
-
-  // State to track reference audio clip span for comparison
-  const [refSpanStart, setRefSpanStart] = useState(0);
-  const [refSpanEnd, setRefSpanEnd] = useState(0);
   
   // Refs to hold mutable recording instances
   const mediaRecorderRef = useRef(null);
@@ -88,6 +84,10 @@ const AudioSelectinPlayer = () => {
       userAudioUrl: userAudioUrl
     });
     
+    // Determine the reference span for comparison. If the user has made a text selection, use that; otherwise, use the full segment.
+    const refSpanStart = selectionData && selectionData.index === index ? selectionData.start : originalSegment.start;
+    const refSpanEnd = selectionData && selectionData.index === index ? selectionData.end : originalSegment.end;
+
     // TODO: Implement your future comparison logic here (e.g., scoring, waveform diffing)
     // 2. Create the FormData payload
     const formData = new FormData();
@@ -186,8 +186,6 @@ const AudioSelectinPlayer = () => {
   // 1. Function to play a specific segment with an end time
   const playClip = (startTime, endTime) => {
     if (audioRef.current) {
-      setRefSpanStart(startTime);
-      setRefSpanEnd(endTime);
       const audio = audioRef.current;
 
       // Jump to start and play

--- a/frontend/src/components/AudioSelectionPlayerRecorder.js
+++ b/frontend/src/components/AudioSelectionPlayerRecorder.js
@@ -26,8 +26,6 @@ const getFirstMatchIndex = (text, pattern) => {
 };
 const AudioSelectinPlayer = () => {
 
-  // ... inside your component:
-  
   // New States for Recording
   const [recordingIndex, setRecordingIndex] = useState(null);
   const [userRecordings, setUserRecordings] = useState({});
@@ -76,7 +74,7 @@ const AudioSelectinPlayer = () => {
     setRecordingIndex(null);
   };
   
-  const handleCompare = (index) => {
+  const handleCompare = async (index) => {
     const userAudioUrl = userRecordings[index];
     const originalSegment = transcriptionClips[index];
     
@@ -87,13 +85,57 @@ const AudioSelectinPlayer = () => {
     });
     
     // TODO: Implement your future comparison logic here (e.g., scoring, waveform diffing)
+    // 2. Create the FormData payload
+    const formData = new FormData();
+
+    const BACKEND_URL = process.env.REACT_APP_BACKEND_URL;
+
+    // Note: Since we only have URLs, we need to fetch the blobs first
+    const referenceResponse = await fetch(audioUrl); 
+    const queryResponse = await fetch(userAudioUrl);
+    if (!referenceResponse.ok || !queryResponse.ok) {
+      throw new Error('Failed to fetch audio files from URLs.');
+    }
+    const referenceBlob = await referenceResponse.blob();
+    const queryBlob = await queryResponse.blob();
+
+    // Append the files
+    formData.append('reference_audio', referenceBlob, 'reference.wav');
+    formData.append('query_audio', queryBlob, 'query.wav');
+    
+    // // Append the final offset. (Backend usually expects strings or numbers)
+    // formData.append('query_start', -offset); 
+    formData.append('ref_span', JSON.stringify({'start': selectionData.start, 'end': selectionData.end})); // Example of sending the selected text span timestamps
+
+    try {
+      const response = await fetch(BACKEND_URL + "/speeches/acoustic_evaluation", {
+          method: "POST",
+          body: formData,
+      });
+
+      if (response.ok) {
+          const result = await response.json();
+          console.log(`✅ Successfully processed! Audio Discrepancy: ${result.score}`);
+
+      } else {
+          console.error('Acoustic Evaluation Error:', response.statusText);
+          alert(`Error ${response.status}: ${response.statusText}`);
+          console.log('❌ Failed to upload. Check your connection or API.');
+      }
+  } catch (error) {
+      console.error('Error:', error);
+      alert(`An error occurred: ${error}`);
+  } 
+  // finally {
+  //     setIsSubmitting(false);
+  //   }
   };
 
   const [selectedFile, setSelectedFile] = useState(null);
   const [audioUrl, setAudioUrl] = useState(null); // URL for the player
   const [transcriptionClips, setTranscriptionClips] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
-  const [selectionData, setSelectionData] = useState(null);
+  const [selectionData, setSelectionData] = useState({});
 
   const audioRef = useRef(null); // Reference to the audio element
 

--- a/frontend/src/components/AudioSelectionPlayerRecorder.js
+++ b/frontend/src/components/AudioSelectionPlayerRecorder.js
@@ -30,6 +30,10 @@ const AudioSelectinPlayer = () => {
   const [recordingIndex, setRecordingIndex] = useState(null);
   const [userRecordings, setUserRecordings] = useState({});
   const [showRecordingTools, setShowRecordingTools] = useState(false);
+
+  // State to track reference audio clip span for comparison
+  const [refSpanStart, setRefSpanStart] = useState(0);
+  const [refSpanEnd, setRefSpanEnd] = useState(0);
   
   // Refs to hold mutable recording instances
   const mediaRecorderRef = useRef(null);
@@ -105,8 +109,8 @@ const AudioSelectinPlayer = () => {
     
     // // Append the final offset. (Backend usually expects strings or numbers)
     // formData.append('query_start', -offset); 
-    formData.append('ref_span', JSON.stringify({'start': selectionData.start, 'end': selectionData.end})); // Example of sending the selected text span timestamps
-
+    formData.append('ref_span', JSON.stringify({'start': refSpanStart, 'end': refSpanEnd})); // Example of sending the selected text span timestamps
+    console.log("ref span: ", JSON.stringify({'start': refSpanStart, 'end': refSpanEnd}));
     try {
       const response = await fetch(BACKEND_URL + "/speeches/acoustic_evaluation", {
           method: "POST",
@@ -182,6 +186,8 @@ const AudioSelectinPlayer = () => {
   // 1. Function to play a specific segment with an end time
   const playClip = (startTime, endTime) => {
     if (audioRef.current) {
+      setRefSpanStart(startTime);
+      setRefSpanEnd(endTime);
       const audio = audioRef.current;
 
       // Jump to start and play


### PR DESCRIPTION
Add recording and audio comparison to each audio segment in `Audio Segment Player`. 

1. When comparing reference audio and user recording, the generation of reference audios is delegated to the backend. No efficient JS library for such purpose is found yet. 
2. Add frontend function to send audio evaluation requests. 

Next Steps:
1. Add visualization to audio comparison as `Sample Reading` does, as well as displaying evaluation results. 
2. Is it necessary to trim audios based on user dragging offsets when alignning waveforms? Test a new audio trimming method with sampling and `ffmpeg` to improve evaluation results. 