### PR TITLE
feat: add sentence-based audio clipping

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -8,6 +8,7 @@ from flask_limiter.errors import RateLimitExceeded
 from flask_limiter.util import get_remote_address
 from utils import (
     clip_speech_to_text,
+    speech_to_text_group_sentence,
     eval_revision,
     evaluate_audio_discrepancy,
     load_fileStorage,
@@ -96,8 +97,13 @@ def transcribe_audio_clip():
 
     audio_file = request.files["audio"]
 
+    clip_option = request.form.get("clip_option", "sentence")  # default to sentence if not provided
+
     try:
-        transcript_clips = clip_speech_to_text(audio_file)
+        if clip_option == "sentence":
+            transcript_clips = speech_to_text_group_sentence(audio_file)
+        else:
+            transcript_clips = clip_speech_to_text(audio_file)
         return jsonify({"transcription": transcript_clips}), 200
     except Exception as e:
         return jsonify({"error": str(e)}), 500

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -45,8 +45,50 @@ def speech_to_text(audio: FileStorage):
     finally:
         os.remove(audio_path)
 
+def speech_to_text_group_sentence(audio: FileStorage) -> List[dict]:
+    """
+    Group the transcription result into sentences based on punctuation. Each sentence will have its own start and end timestamps, as well as character-level timestamps for each character in the sentence. \n
+    """
+    elevenlabs = ElevenLabs(
+        api_key=os.getenv("ELEVENLABS_API_KEY"),
+    )
+    audio_path = tempfile.NamedTemporaryFile(
+        delete=False, suffix=os.path.splitext(audio.filename)[1]
+    ).name  # Create a temporary file sharing the same extension as the input audio file
+    audio.save(audio_path)  # Save the FileStorage Object to the temporary file
+
+    audio_file = open(audio_path, "rb")
+
+    try:
+        transcription = elevenlabs.speech_to_text.convert(
+            file=audio_file,
+            model_id="scribe_v1",  # Model to use
+            tag_audio_events=True,  # Tag audio events like laughter, applause, etc.
+            timestamps_granularity="character",
+            diarize=False,
+        ).model_dump(mode="json")
+        sentences = []
+        current_sentence = []
+        for word in transcription['words']:
+            current_sentence.append(word)
+            if word['text'].endswith(('.', '!', '?')):
+                sentences.append({
+                    "start": current_sentence[0]['start'],
+                    "end": current_sentence[-1]['end'],
+                    "text": ' '.join(w['text'] for w in current_sentence),
+                    "characters": [c for w in current_sentence for c in w['characters']]
+                })
+                current_sentence = []
+        return sentences
+    except Exception as e:
+        raise Exception(str(e))
+    finally:
+        os.remove(audio_path)
 
 def clip_speech_to_text(audio: FileStorage) -> List[dict]:
+    """
+    Group the transcription result into clips based on speaker diarization. Each clip will have its own start and end timestamps, as well as character-level timestamps for each character in the clip. \n
+    """
     elevenlabs = ElevenLabs(
         api_key=os.getenv("ELEVENLABS_API_KEY"),
     )

--- a/frontend/src/components/AudioSelectionPlayer.js
+++ b/frontend/src/components/AudioSelectionPlayer.js
@@ -30,6 +30,7 @@ const AudioSelectinPlayer = () => {
   const [transcriptionClips, setTranscriptionClips] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
   const [selectionData, setSelectionData] = useState(null);
+  const [clipOption, setClipOption] = useState('speaker'); // 'speaker' or 'sentence'
 
   const audioRef = useRef(null); // Reference to the audio element
 
@@ -53,6 +54,12 @@ const AudioSelectinPlayer = () => {
     formData.append('audio', selectedFile);
 
     try {
+      if (clipOption === 'speaker') {
+        formData.append('clip_option', 'speaker');
+      }
+      else {
+        formData.append('clip_option', 'sentence');
+      }
       const response = await fetch(BACKEND_URL + '/speeches/transcription_clips', {
         method: 'POST',
         body: formData,
@@ -149,6 +156,27 @@ const AudioSelectinPlayer = () => {
           <audio ref={audioRef} src={audioUrl} controls style={styles.audioPlayer} />
         </div>
       )}
+
+      <div style={styles.optionsContainer}>
+        <label>
+          <input 
+            type="radio" 
+            name="clipOption" 
+            value="speaker" 
+            onChange={() => setClipOption("speaker")} 
+          />
+          Speaker-based Clipping
+        </label>
+        <label>
+          <input 
+            type="radio" 
+            name="clipOption" 
+            value="sentence" 
+            onChange={() => setClipOption("sentence")} 
+          />
+          Sentence-based Clipping
+        </label>
+      </div>
 
       <button onClick={handleUpload} disabled={!selectedFile || isLoading}>
         {isLoading ? 'Processing...' : 'Transcribe & Clip'}


### PR DESCRIPTION
For monologues, speaker diarization can't help much to break down recording transcriptions. Then, a sentence-based segmentation is added in this PR. Given transcription words returned by ELVENLAB, sentences here are defined by words ended with symbols of ".", "!", "?". 

Next Steps: unifying two kinds of transcription segmentation in the backend, and possibly optimize UI. 