### PR TITLE
Feature/sample reading multilinguial

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -14,6 +14,7 @@ from utils import (
     load_fileStorage,
     speech_to_text,
     text_to_text,
+    text_to_speech_multilingual
 )
 
 import redis  # noqa
@@ -111,14 +112,13 @@ def transcribe_audio_clip():
 
 @app.route("/api/speeches/generate/synthesis", methods=["POST"])
 def generate_speech():
-    # data = json.loads(request.data)
+    data = json.loads(request.data)
     try:
-        # audio_data = text_to_speech(data["text"])
-        with open("generated.wav", "rb") as f:
-            audio_data = f.read()
+        audio_data = text_to_speech_multilingual(data["text"], data.get("language", "en"))
 
     except Exception as e:
         return jsonify({"error": str(e)}), 500
+    
     return app.response_class(audio_data, mimetype="audio/wav")
 
 

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -232,8 +232,19 @@ def text_to_speech(input_text):
     # logging.info(f"Generated audio file saved at {audio_path}")
     return response.read()
 
+def text_to_speech_multilingual(input_text: str, language_code: str):
 
-
+    client = ElevenLabs(
+        api_key=os.getenv("ELEVENLABS_API_KEY"),
+    )
+    reps = client.text_to_speech.convert(
+        voice_id="JBFqnCBsd6RMkjVDRZzb",
+        output_format="mp3_44100_128",
+        text=input_text,
+        model_id="eleven_flash_v2_5",
+        language_code=language_code
+    )
+    return reps
 
 def trim_audio(
     input_file: str, output_file: str, start_sec: float, end_sec: float = None


### PR DESCRIPTION
Use ElevenLab for speech synthesis, espeically languages outside English. However, when it comes to timestamps, the frontend cannot render decoded audio data. Text selection of audio segments may be preferred when shadow reading a long or complicated sentence. It'd be also better to allow users indicate of which language they want to synthesis for better audio quality. 